### PR TITLE
fix: node v17 and above with FETCH integrated fails to generate graph

### DIFF
--- a/index.js
+++ b/index.js
@@ -453,8 +453,12 @@ const nodeFs = require('fs');
               !wasmBinary &&
               typeof WebAssembly.instantiateStreaming === 'function' &&
               !isDataURI(wasmBinaryFile) &&
-              typeof fetch === 'function'
-            ) {
+              typeof fetch === 'function',
+              typeof process !== 'object' // only if NOT Node environment
+              ) {
+              // Node v17 and above fails on `fetch` since Node has `fetch` integrated natively.
+              // So `fetch === function` is actually true.
+              // Error is: `ERR_INVALID_URL` since it cannot fetch local files eg.: "./graphvizlib.wasm"
               fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(
                 function (response) {
                   var result = WebAssembly.instantiateStreaming(response, info);


### PR DESCRIPTION
Maybe I got this wrong but since this library was released 2 years ago I would assume checking `typeof fetch === 'function'` was a mechanism to differentiate between `node` and `browser` environment.

So what happened now is that `fetch` in Node v17 and above does have `fetch` integrated and this check will pass.
But soon it will fail with an `INVALID_URL` error since it will try to fetch the local file (graphvizlib.wasm).

As a workaround, I added one more check for `process` to make sure the script is not running in Node.

If I am totally wrong and you want to fix this differently or run `fetch` in Node, feel free to discard this PR.

In our use case in the [@sasjs/cli](https://github.com/sasjs/cli/blob/59ef224d993efdfb0cd0a4e0ad65dc4f708989d1/src/commands/docs/internal/createDotFiles.ts#L30) this fix will be totally acceptable since it is never run in the browser.